### PR TITLE
①不要なトランザクションの削除②配信者によるモデレーション (NGワード登録) N+1問題対応

### DIFF
--- a/home/isucon/webapp/go/livecomment_handler.go
+++ b/home/isucon/webapp/go/livecomment_handler.go
@@ -388,28 +388,14 @@ func moderateHandler(c echo.Context) error {
 
 	// NGワードにヒットする過去の投稿も全削除する
 	for _, ngword := range ngwords {
-		// ライブコメント一覧取得
-		var livecomments []*LivecommentModel
-		if err := tx.SelectContext(ctx, &livecomments, "SELECT * FROM livecomments"); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livecomments: "+err.Error())
-		}
-
-		for _, livecomment := range livecomments {
-			query := `
+		query := `
 			DELETE FROM livecomments
 			WHERE
-			id = ? AND
-			livestream_id = ? AND
-			(SELECT COUNT(*)
-			FROM
-			(SELECT ? AS text) AS texts
-			INNER JOIN
-			(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
-			ON texts.text LIKE patterns.pattern) >= 1;
+			  livestream_id = ? AND
+			  livecomments.comment LIKE '%?%';
 			`
-			if _, err := tx.ExecContext(ctx, query, livecomment.ID, livestreamID, livecomment.Comment, ngword.Word); err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
-			}
+		if _, err := tx.ExecContext(ctx, query, livestreamID, ngword.Word); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
 		}
 	}
 

--- a/home/isucon/webapp/go/livecomment_handler.go
+++ b/home/isucon/webapp/go/livecomment_handler.go
@@ -388,28 +388,29 @@ func moderateHandler(c echo.Context) error {
 
 	// NGワードにヒットする過去の投稿も全削除する
 	for _, ngword := range ngwords {
-		// ライブコメント一覧取得
-		var livecomments []*LivecommentModel
-		if err := tx.SelectContext(ctx, &livecomments, "SELECT * FROM livecomments"); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livecomments: "+err.Error())
-		}
-
-		for _, livecomment := range livecomments {
-			query := `
-			DELETE FROM livecomments
-			WHERE
-			id = ? AND
-			livestream_id = ? AND
-			(SELECT COUNT(*)
+		query := `
+			DELETE 
 			FROM
-			(SELECT ? AS text) AS texts
-			INNER JOIN
-			(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
-			ON texts.text LIKE patterns.pattern) >= 1;
+				livecomments 
+			WHERE
+				livestream_id = ? 
+				AND ( 
+					SELECT
+						COUNT(*) 
+					FROM
+						( 
+							SELECT
+								comment 
+							FROM
+								livecomments 
+							WHERE
+								livecomments.livestream_id = ? 
+								AND livecomments.comment LIKE CONCAT('%', ?, '%')
+						) AS comments
+				) >= 1;
 			`
-			if _, err := tx.ExecContext(ctx, query, livecomment.ID, livestreamID, livecomment.Comment, ngword.Word); err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
-			}
+		if _, err := tx.ExecContext(ctx, query, livestreamID, livestreamID, ngword.Word); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
 		}
 	}
 

--- a/home/isucon/webapp/go/livecomment_handler.go
+++ b/home/isucon/webapp/go/livecomment_handler.go
@@ -388,14 +388,28 @@ func moderateHandler(c echo.Context) error {
 
 	// NGワードにヒットする過去の投稿も全削除する
 	for _, ngword := range ngwords {
-		query := `
+		// ライブコメント一覧取得
+		var livecomments []*LivecommentModel
+		if err := tx.SelectContext(ctx, &livecomments, "SELECT * FROM livecomments"); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livecomments: "+err.Error())
+		}
+
+		for _, livecomment := range livecomments {
+			query := `
 			DELETE FROM livecomments
 			WHERE
-			  livestream_id = ? AND
-			  livecomments.comment LIKE '%?%';
+			id = ? AND
+			livestream_id = ? AND
+			(SELECT COUNT(*)
+			FROM
+			(SELECT ? AS text) AS texts
+			INNER JOIN
+			(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
+			ON texts.text LIKE patterns.pattern) >= 1;
 			`
-		if _, err := tx.ExecContext(ctx, query, livestreamID, ngword.Word); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
+			if _, err := tx.ExecContext(ctx, query, livecomment.ID, livestreamID, livecomment.Comment, ngword.Word); err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
+			}
 		}
 	}
 

--- a/home/isucon/webapp/go/livecomment_handler.go
+++ b/home/isucon/webapp/go/livecomment_handler.go
@@ -389,27 +389,12 @@ func moderateHandler(c echo.Context) error {
 	// NGワードにヒットする過去の投稿も全削除する
 	for _, ngword := range ngwords {
 		query := `
-			DELETE 
-			FROM
-				livecomments 
+			DELETE FROM livecomments
 			WHERE
-				livestream_id = ? 
-				AND ( 
-					SELECT
-						COUNT(*) 
-					FROM
-						( 
-							SELECT
-								comment 
-							FROM
-								livecomments 
-							WHERE
-								livecomments.livestream_id = ? 
-								AND livecomments.comment LIKE CONCAT('%', ?, '%')
-						) AS comments
-				) >= 1;
+			  livestream_id = ? AND
+			  livecomments.comment LIKE CONCAT('%', ?, '%');
 			`
-		if _, err := tx.ExecContext(ctx, query, livestreamID, livestreamID, ngword.Word); err != nil {
+		if _, err := tx.ExecContext(ctx, query, livestreamID, ngword.Word); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete old livecomments that hit spams: "+err.Error())
 		}
 	}

--- a/home/isucon/webapp/go/livestream_handler.go
+++ b/home/isucon/webapp/go/livestream_handler.go
@@ -178,7 +178,6 @@ func searchLivestreamsHandler(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to begin transaction: "+err.Error())
 	}
-	defer tx.Rollback()
 
 	var livestreamModels []*LivestreamModel
 	if c.QueryParam("tag") != "" {
@@ -228,10 +227,6 @@ func searchLivestreamsHandler(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to fill livestream: "+err.Error())
 		}
 		livestreams[i] = livestream
-	}
-
-	if err := tx.Commit(); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to commit: "+err.Error())
 	}
 
 	return c.JSON(http.StatusOK, livestreams)


### PR DESCRIPTION
## 不要なトランザクションの削除について
#### 参考
- UserのstaticsのN+1の解消 #24
https://github.com/niftyisucon/isucon13/pull/27/commits/bb9619cef74e594e4de3d249e42f44b4f6038a1b
※別の箇所の対応だが、トランザクションの設定の仕方が似ていたので参考にした

## 配信者によるモデレーション (NGワード登録) N+1問題対応について
#### 参考記事
- CONCAT関数(複数の文字列を連結した文字列を取得する)
  - https://www.javadrive.jp/mysql/function/index35.html

