### PR TITLE
バッファプールサイズの設定

### DIFF
--- a/etc/mysql/mysql.conf.d/mysqld.cnf
+++ b/etc/mysql/mysql.conf.d/mysqld.cnf
@@ -76,3 +76,6 @@ long_query_time = 0
 max_binlog_size   = 100M
 # binlog_do_db		= include_database_name
 # binlog_ignore_db	= include_database_name
+
+# バッファプールサイズの設定(free --humanの結果から計算)
+innodb_buffer_pool_size = 2G


### PR DESCRIPTION
## 参考記事
- デフォルト設定はNG？MySQLのメモリのチューニング手順
  - https://www.manageengine.jp/products/Applications_Manager/solution_mysql-memory-tuning.html
- innodb_dedicated_serverによるbuffer_poolの割り当て
  - https://gihyo.jp/dev/serial/01/mysql-road-construction-news/0092

## メモ
※innodb_buffer_pool_sizeを設定する基準(free --humanの結果を基準とする)
|メモリ |innodb_buffer_pool_size|
|---------|-----------------------|
|1GB未満 |128MB |
|1GB～4GB |メモリの50% |
|4GB以上 |メモリの75% |
